### PR TITLE
Fix incorrect key name in response

### DIFF
--- a/opensight_restserver.py
+++ b/opensight_restserver.py
@@ -156,7 +156,7 @@ def format_utxo_from_electrum(utxo, best_block, address, p2pkh_script):
 
 def format_tx_vin(vin, n):
     tx_vout = call_method_node("getrawtransaction", [vin["txid"], True])
-    vin["value"] = tx_vout["vout"][vin["vout"]]["value"]
+    vin["valueSat"] = tx_vout["vout"][vin["vout"]]["value"]
     vin["n"] = n
     vin["doubleSpentTxID"] = None
     return vin
@@ -188,7 +188,7 @@ def get_tx_details(tx_hash):
 
     tx.pop("hex", None)
 
-    tx["valueIn"] = sum([vin["value"] for vin in tx["vin"]])
+    tx["valueIn"] = sum([vin["valueSat"] for vin in tx["vin"]])
     tx["valueOut"] = sum([vout["value"] for vout in tx["vout"]])
 
     tx["fees"] = tx["valueIn"] - tx["valueOut"]


### PR DESCRIPTION
Incorrect key name was used, causing rest.bitcoin.com not to see or use the provided value.
The name has been changed to what rest.bitcoin.com expects, and now displays correctly.